### PR TITLE
feat: add partition export module for link-list-torus schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,12 @@ python scripts/visualize_partition.py --solution <path_to_solution.h5>
 python scripts/visualize_type1_vertex_collapse.py --solution <path_to_refined.h5> --region 2
 python scripts/visualize_type2_triple_point.py --solution <path_to_refined.h5> --region 2
 
+# Export finalised partition to link-list-torus HDF5 schema
+python scripts/export_partition.py \
+ --solution results/<run>/refinement/<campaign>/iteration_NNN_*.h5 \
+ --config parameters/torus_10part.yaml \
+ --output results/<run>/partition/torus_partition_<run-id>.h5
+
 # Analysis
 python scripts/optimization_analyzer.py --results-dir results/<run_dir>
 
@@ -110,6 +116,10 @@ src/
 │   ├── relaxation.py             # run_relaxation(): multi-level PGD pipeline (Phase 1)
 │   ├── pipeline_orchestrator.py  # PipelineOrchestrator, RefinementConfig, derive_output_paths (Phase 2)
 │   └── io.py                     # HDF5 loaders, detect_run_layout(), find_base_solution_path()
+├── export/
+│   ├── __init__.py              # public API: export_partition()
+│   ├── rep3_builder.py          # builds subdivided mesh (Representation 3)
+│   └── writer.py                # assembles and writes the export HDF5
 ├── visualization/
 │   ├── plot_utils.py             # Matplotlib utilities
 │   ├── partition_helpers.py      # Partition-specific viz helpers (cell coloring, VP/Steiner markers)
@@ -124,6 +134,7 @@ scripts/
 ├── visualize_partition.py        # Original partition viewer — debugging (PyVista)
 ├── visualize_type1_vertex_collapse.py  # Type 1 migration debugging viewer
 ├── visualize_type2_triple_point.py     # Type 2 migration debugging viewer
+├── export_partition.py           # Export finalised partition to link-list-torus schema
 └── debug_archive/                # Archived diagnostic scripts
 testing/
 ├── README_testing.md                    # Test registry documentation

--- a/docs/plans/PIPELINE_EXPORT_INTEGRATION.md
+++ b/docs/plans/PIPELINE_EXPORT_INTEGRATION.md
@@ -1,0 +1,113 @@
+# Pipeline Integration of the Partition Export
+
+**Status:** Planned. Prerequisite: `scripts/export_partition.py` must be
+production-tested on at least one run before pipeline integration is attempted.
+**Audience:** Future agent / developer adding automatic export at the end of
+Phase 2.
+**Related:** `src/export/`, `scripts/export_partition.py`,
+`scripts/refine_perimeter.py`,
+`../link-list-torus/docs/design/PARTITION_INPUT_ASSESSMENT.md`.
+
+---
+
+## TL;DR
+
+`src/export/export_partition()` was deliberately written to accept already-
+loaded Python objects (mesh, partition, Steiner handler, config) rather than
+opening files. That makes it callable from both the standalone CLI
+(`scripts/export_partition.py`, available today) and the Phase-2 pipeline
+itself (this document). No refactoring of `src/export/` is required.
+
+This document specifies the wiring that turns the standalone CLI into an
+opt-in pipeline step.
+
+---
+
+## What to implement
+
+1. **CLI flag** on `scripts/refine_perimeter.py`:
+
+   ```
+   --export / --no-export
+   ```
+
+   Default off. When on, the export runs once at the end of the refinement
+   loop. The flag also accepts a YAML value via `RefinementConfig`.
+
+2. **Config field** on `RefinementConfig`
+   (`src/pipeline/pipeline_orchestrator.py`):
+
+   ```python
+   export: bool = False
+   ```
+
+   Read in `from_yaml_dict()` from the `refinement.export` key; overridable
+   on the CLI.
+
+3. **End-of-loop call** in
+   `PipelineOrchestrator.run_refinement_loop()`. After the loop exits
+   (whether converged or hit `max_iterations`), if `self.config.export`:
+
+   - Resolve the run YAML by reading `<run_dir>/experiment.yaml`
+     (or carry it through from `find_surface_partition.py`).
+   - Read `R`, `r`, `n_theta`, `n_phi` from `config['surface']['torus']`.
+   - Resolve `source_run_id = Path(run_dir).name`.
+   - Resolve `source_iteration` from the final-iteration counter the loop
+     already maintains.
+   - Read `seed` from the base solution HDF5 attributes (already loaded
+     during the run; cache it at start of `run_refinement_loop`).
+   - Call:
+
+     ```python
+     export_partition(
+         partition=self.partition,
+         mesh=self.mesh,
+         steiner_handler=self.steiner_handler,
+         config=experiment_config,
+         output_path=output_path,
+         source_run_id=source_run_id,
+         source_iteration=source_iteration,
+         seed=seed,
+         final_perimeter=final_perimeter,
+         pending_migration=pending_migration,
+         strict=False,
+     )
+     ```
+
+   `strict=False` is intentional: a run that exhausts `max_iterations` may
+   still have `pending_migration=True` at the final checkpoint, and we still
+   want a file written (with `finalised=False`) for downstream inspection.
+
+4. **Output path convention:**
+
+   ```
+   <run_dir>/refinement/<campaign>/torus_partition_<run_id>.h5
+   ```
+
+   This places the export alongside the iteration checkpoints in the same
+   campaign directory. The standalone CLI already defaults to this layout
+   when invoked without `--output`.
+
+---
+
+## What NOT to do
+
+- Do **not** refactor `src/export/` — its signature and split (rep3 builder
+  vs. writer) was chosen to support this integration without changes.
+- Do **not** make the export non-optional. The standalone CLI must keep
+  working for ad-hoc exports of older runs.
+- Do **not** silently overwrite an existing file at the output path; either
+  add a `--force` flag or fail with a clear message. (Pick one when
+  implementing — `--force` is the convention used in the standalone CLI's
+  parent scripts.)
+- Do **not** import `cyipopt`, `pyvista`, or other optional dependencies
+  from the export module. The export should run in the core install.
+
+---
+
+## Verification
+
+The change is verified end-to-end by a Phase-2 run with `--export` that
+produces a `torus_partition_<run-id>.h5` alongside the iteration checkpoints
+and passes the structural check from §11 of the original task prompt
+(`prompts/prompt.md`).

--- a/scripts/export_partition.py
+++ b/scripts/export_partition.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Export a Phase-2 checkpoint to the link-list-torus partition HDF5 schema.
+
+This is a thin CLI wrapper around `src.export.export_partition`. It loads the
+checkpoint and base solution via the existing pipeline I/O, materialises the
+Steiner geometry, and writes one self-contained file in the schema documented
+in `../link-list-torus/docs/design/PARTITION_INPUT_ASSESSMENT.md`.
+
+Usage:
+    python scripts/export_partition.py \
+        --solution results/<run>/refinement/<campaign>/iteration_NNN_*.h5 \
+        --config parameters/torus_10part.yaml \
+        --output results/<run>/partition/torus_partition_<run-id>.h5
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import h5py
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.export import export_partition
+from src.partition.steiner_handler import SteinerHandler
+from src.pipeline.io import find_base_solution_path, load_partition_from_refined_file
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Export a Phase-2 checkpoint to the link-list-torus schema"
+    )
+    parser.add_argument(
+        "--solution", type=str, required=True,
+        help="Path to a Phase-2 iteration checkpoint HDF5 file."
+    )
+    parser.add_argument(
+        "--config", type=str, required=True,
+        help="Path to the experiment YAML containing surface.torus radii."
+    )
+    parser.add_argument(
+        "--output", type=str, default=None,
+        help="Output HDF5 path. Default: <run_dir>/partition/torus_partition_<run-id>.h5"
+    )
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="Raise an error if the checkpoint has pending_migration=True. "
+             "Default is permissive (warn and continue, writing finalised=False)."
+    )
+    args = parser.parse_args()
+
+    checkpoint_path = os.path.abspath(args.solution)
+    if not os.path.exists(checkpoint_path):
+        print(f"ERROR: checkpoint not found: {checkpoint_path}")
+        return 1
+
+    with open(args.config, "r") as f:
+        config = yaml.safe_load(f) or {}
+
+    if "surface" not in config or "torus" not in config["surface"]:
+        print("ERROR: config has no surface.torus section (R, r, n_theta, n_phi)")
+        return 1
+
+    run_dir = Path(checkpoint_path).parent.parent.parent
+    source_run_id = run_dir.name
+
+    with h5py.File(checkpoint_path, "r") as f:
+        source_iteration = int(f.attrs["iteration_number"])
+        final_perimeter = float(f.attrs["final_perimeter"])
+        pending_migration = bool(f.attrs.get("pending_migration", False))
+
+    base_solution_path = find_base_solution_path(checkpoint_path, verbose=True)
+    with h5py.File(base_solution_path, "r") as f:
+        seed = int(f.attrs["seed"])
+
+    mesh, partition = load_partition_from_refined_file(checkpoint_path, verbose=True)
+    steiner_handler = SteinerHandler(mesh, partition)
+
+    if args.output:
+        output_path = os.path.abspath(args.output)
+    else:
+        partition_dir = run_dir / "partition"
+        partition_dir.mkdir(exist_ok=True)
+        output_path = str(partition_dir / f"torus_partition_{source_run_id}.h5")
+
+    export_partition(
+        partition=partition,
+        mesh=mesh,
+        steiner_handler=steiner_handler,
+        config=config,
+        output_path=output_path,
+        source_run_id=source_run_id,
+        source_iteration=source_iteration,
+        seed=seed,
+        final_perimeter=final_perimeter,
+        pending_migration=pending_migration,
+        strict=args.strict,
+    )
+
+    print(f"Exported partition to: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/export/__init__.py
+++ b/src/export/__init__.py
@@ -1,0 +1,5 @@
+"""Partition export package for the link-list-torus schema."""
+
+from .writer import export_partition
+
+__all__ = ["export_partition"]

--- a/src/export/rep3_builder.py
+++ b/src/export/rep3_builder.py
@@ -1,0 +1,125 @@
+"""
+Build Representation 3: subdivided mesh with explicit per-face cell labels.
+
+Given the original mesh, the active variable points, and the triple-point /
+Steiner geometry, this produces three flat arrays:
+
+- ``sub_vertices`` (V + n_vp + n_tp, 3) — original mesh vertices followed by
+  active-VP positions followed by Steiner points.
+- ``sub_faces``    (F_sub, 3)            — connectivity into ``sub_vertices``.
+- ``face_labels``  (F_sub,)              — cell label per sub-triangle.
+
+The vertex-index layout in ``sub_vertices`` is:
+
+    indices  0 .. V-1                          → original mesh vertices
+    indices  V .. V+n_vp-1                     → active VP positions (order of
+                                                 ``active_vps``)
+    indices  V+n_vp .. V+n_vp+n_tp-1           → Steiner points (order of
+                                                 ``steiner_handler.triple_points``)
+"""
+
+from typing import List, Tuple
+
+import numpy as np
+
+
+def build_representation_3(
+    partition,
+    mesh,
+    active_vps: List,
+    steiner_handler,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    vertices = mesh.vertices
+    V = vertices.shape[0]
+    n_vp = len(active_vps)
+    triple_points = steiner_handler.triple_points
+    n_tp = len(triple_points)
+
+    vertex_labels = partition.indicator_functions.argmax(axis=1).astype(np.int32)
+    n_cells = partition.n_cells
+
+    sub_vertices = np.empty((V + n_vp + n_tp, 3), dtype=np.float64)
+    sub_vertices[:V] = vertices
+    for k, vp in enumerate(active_vps):
+        sub_vertices[V + k] = vp.evaluate(vertices)
+    for k, tp in enumerate(triple_points):
+        sub_vertices[V + n_vp + k] = tp.steiner_point
+
+    vp_global_idx = {id(vp): V + k for k, vp in enumerate(active_vps)}
+    steiner_global_idx = {
+        tp.triangle_idx: V + n_vp + k for k, tp in enumerate(triple_points)
+    }
+    edge_to_sub_idx = {frozenset(vp.edge): V + k for k, vp in enumerate(active_vps)}
+    triple_lookup = {tp.triangle_idx: tp for tp in triple_points}
+
+    sub_faces: List[Tuple[int, int, int]] = []
+    face_labels: List[int] = []
+
+    for tri_idx, face in enumerate(mesh.faces):
+        a, b, c = int(face[0]), int(face[1]), int(face[2])
+        la, lb, lc = (
+            int(vertex_labels[a]),
+            int(vertex_labels[b]),
+            int(vertex_labels[c]),
+        )
+        label_set = {la, lb, lc}
+
+        if len(label_set) == 1:
+            sub_faces.append((a, b, c))
+            face_labels.append(la)
+            continue
+
+        if len(label_set) == 2:
+            verts = [a, b, c]
+            labs = [la, lb, lc]
+            for i in range(3):
+                if labs.count(labs[i]) == 1:
+                    lone_i = i
+                    break
+            v_lone = verts[lone_i]
+            pair_indices = [i for i in range(3) if i != lone_i]
+            v_p0 = verts[pair_indices[0]]
+            v_p1 = verts[pair_indices[1]]
+
+            edge0 = frozenset((v_lone, v_p0))
+            edge1 = frozenset((v_lone, v_p1))
+            vp0_idx = edge_to_sub_idx[edge0]
+            vp1_idx = edge_to_sub_idx[edge1]
+
+            label_lone = labs[lone_i]
+            label_pair = labs[pair_indices[0]]
+
+            sub_faces.append((v_lone, vp0_idx, vp1_idx))
+            face_labels.append(label_lone)
+            sub_faces.append((v_p0, v_p1, vp1_idx))
+            face_labels.append(label_pair)
+            sub_faces.append((v_p0, vp1_idx, vp0_idx))
+            face_labels.append(label_pair)
+            continue
+
+        # triple-point triangle
+        tp = triple_lookup[tri_idx]
+        steiner_idx = steiner_global_idx[tri_idx]
+        for c_k in tp.cell_indices:
+            pair = [
+                vp_global_idx[id(partition.variable_points[vi])]
+                for vi in tp.var_point_indices
+                if c_k in partition.variable_points[vi].belongs_to_cells
+            ]
+            if len(pair) != 2:
+                raise ValueError(
+                    f"Triple point at triangle {tri_idx}: cell {c_k} bounded by "
+                    f"{len(pair)} VPs, expected 2"
+                )
+            sub_faces.append((pair[0], pair[1], steiner_idx))
+            face_labels.append(c_k)
+
+    sub_faces_arr = np.array(sub_faces, dtype=np.int32)
+    face_labels_arr = np.array(face_labels, dtype=np.int32)
+
+    assert face_labels_arr.min() >= 0 and face_labels_arr.max() < n_cells, (
+        f"face_labels out of range [0, {n_cells - 1}]: "
+        f"min={face_labels_arr.min()}, max={face_labels_arr.max()}"
+    )
+
+    return sub_vertices, sub_faces_arr, face_labels_arr

--- a/src/export/writer.py
+++ b/src/export/writer.py
@@ -1,0 +1,162 @@
+"""
+Assemble and write the link-list-torus partition export HDF5.
+
+The schema is documented in `../link-list-torus/docs/design/PARTITION_INPUT_ASSESSMENT.md`
+and reproduced in §5 of `prompts/prompt.md`.
+"""
+
+from datetime import datetime, timezone
+import logging
+import os
+import subprocess
+from typing import Optional
+
+import h5py
+import numpy as np
+
+from .rep3_builder import build_representation_3
+
+
+logger = logging.getLogger(__name__)
+
+
+def _git_sha() -> str:
+    try:
+        repo_root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+        )
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if out.returncode == 0:
+            return out.stdout.strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def export_partition(
+    partition,
+    mesh,
+    steiner_handler,
+    config: dict,
+    output_path: str,
+    source_run_id: str,
+    source_iteration: int,
+    seed: int,
+    final_perimeter: float,
+    pending_migration: bool,
+    strict: bool = False,
+) -> None:
+    """Export a finalised torus partition to the link-list-torus HDF5 schema.
+
+    All inputs are already-loaded Python objects; this function does not open
+    any input files. It builds Representation 3, packages the canonical
+    snapshot, and writes one self-contained HDF5 file at ``output_path``.
+
+    The ``finalised`` flag is set to ``not pending_migration``. When
+    ``pending_migration`` is True, a warning is emitted (or, with
+    ``strict=True``, an error is raised) but the export is not blocked unless
+    ``strict`` is set.
+    """
+    if pending_migration:
+        msg = (
+            "This checkpoint has a pending topology migration; the partition "
+            "state may shift in the next iteration. Exporting with "
+            "finalised=False."
+        )
+        if strict:
+            raise RuntimeError(msg)
+        logger.warning(msg)
+        print(f"WARNING: {msg}")
+
+    torus_cfg = config["surface"]["torus"]
+    R = float(torus_cfg["R"])
+    r = float(torus_cfg["r"])
+    n_theta = int(torus_cfg["n_theta"])
+    n_phi = int(torus_cfg["n_phi"])
+
+    active_vps = [vp for vp in partition.variable_points if vp.active]
+    n_vp = len(active_vps)
+    n_tp = len(steiner_handler.triple_points)
+    n_cells = int(partition.n_cells)
+
+    vertex_labels = partition.indicator_functions.argmax(axis=1).astype(np.int32)
+    V = mesh.vertices.shape[0]
+
+    sub_vertices, sub_faces, face_labels = build_representation_3(
+        partition, mesh, active_vps, steiner_handler
+    )
+
+    vp_edges = np.empty((n_vp, 2), dtype=np.int64)
+    vp_lambda = np.empty(n_vp, dtype=np.float64)
+    for k, vp in enumerate(active_vps):
+        vp_edges[k, 0] = vp.edge[0]
+        vp_edges[k, 1] = vp.edge[1]
+        vp_lambda[k] = vp.lambda_param
+
+    triangle_index = np.empty(n_tp, dtype=np.int32)
+    cell_triple = np.empty((n_tp, 3), dtype=np.int32)
+    steiner_xyz = np.empty((n_tp, 3), dtype=np.float64)
+    for k, tp in enumerate(steiner_handler.triple_points):
+        triangle_index[k] = tp.triangle_idx
+        if len(tp.cell_indices) != 3:
+            raise ValueError(
+                f"Triple point at triangle {tp.triangle_idx} has "
+                f"{len(tp.cell_indices)} cells, expected 3"
+            )
+        cell_triple[k] = np.asarray(tp.cell_indices, dtype=np.int32)
+        steiner_xyz[k] = tp.steiner_point
+
+    os.makedirs(os.path.dirname(os.path.abspath(output_path)) or ".", exist_ok=True)
+
+    finalised = not pending_migration
+    created = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    with h5py.File(output_path, "w") as f:
+        f.attrs["schema_version"] = "1.0"
+        f.attrs["surface"] = "torus"
+        f.attrs["n_cells"] = n_cells
+        f.attrs["R"] = R
+        f.attrs["r"] = r
+        f.attrs["finalised"] = bool(finalised)
+        f.attrs["source_run_id"] = source_run_id
+        f.attrs["source_iteration"] = int(source_iteration)
+        f.attrs["seed"] = int(seed)
+        f.attrs["final_perimeter"] = float(final_perimeter)
+        f.attrs["surface_partition_git_sha"] = _git_sha()
+        f.attrs["created"] = created
+
+        mesh_grp = f.create_group("mesh")
+        mesh_grp.create_dataset("vertices", data=mesh.vertices.astype(np.float64))
+        mesh_grp.create_dataset("faces", data=mesh.faces.astype(np.int32))
+        mesh_grp.attrs["grid_shape"] = np.array([n_theta, n_phi], dtype=np.int32)
+        mesh_grp.attrs["vertex_order"] = (
+            "theta-major row-major: vertex[i*n_phi + j] is at (theta_i, phi_j)"
+        )
+
+        part_grp = f.create_group("partition")
+        part_grp.create_dataset("sub_vertices", data=sub_vertices)
+        part_grp.create_dataset("sub_faces", data=sub_faces)
+        part_grp.create_dataset("face_labels", data=face_labels)
+        part_grp.attrs["n_original_vertices"] = V
+
+        snap_grp = f.create_group("snapshot")
+        snap_grp.create_dataset("vertex_labels", data=vertex_labels)
+        snap_grp.create_dataset("vp_edges", data=vp_edges)
+        snap_grp.create_dataset("vp_lambda", data=vp_lambda)
+        snap_grp.attrs["n_variable_points"] = n_vp
+
+        tp_grp = snap_grp.create_group("triple_points")
+        tp_grp.create_dataset("triangle_index", data=triangle_index)
+        tp_grp.create_dataset("cell_triple", data=cell_triple)
+        tp_grp.create_dataset("steiner_xyz", data=steiner_xyz)
+
+    logger.info(
+        f"Exported partition to {output_path}: V={V}, n_vp={n_vp}, n_tp={n_tp}, "
+        f"n_cells={n_cells}, finalised={finalised}"
+    )


### PR DESCRIPTION
## Summary
- New `src/export/` package with `export_partition()` that takes already-loaded mesh/partition/Steiner objects and writes a self-contained HDF5 in the link-list-torus schema (Representation 3 subdivided mesh + canonical snapshot).
- `scripts/export_partition.py` CLI wrapper; permissive by default on `pending_migration=True`, `--strict` flag raises.
- Deferred plan in `docs/plans/PIPELINE_EXPORT_INTEGRATION.md` for wiring the export into the Phase 2 pipeline.
- Pure addition — no existing code touched apart from `CLAUDE.md` directory-layout / Build & Run entries.

## Test plan
- [x] `from src.export import export_partition` imports cleanly
- [x] Export ran end-to-end on `iteration_016_*.h5` (pending_migration=True): `finalised=False`, warning emitted, file written
- [x] Structural check passed: `sub_vertices == V + n_vp + n_tp` (249736), `F_sub == n_pure + 3·n_b2 + 3·n_t3` (499412), `face_labels`/`vertex_labels` ∈ [0, 9], all root attrs present
- [x] `--strict` mode raises and writes no file on `pending_migration=True`
- [ ] Not yet exercised: a checkpoint with `pending_migration=False` (the `finalised=True` path)